### PR TITLE
Fixed previous and next buttons on mobile

### DIFF
--- a/css/stanford_carousel.css
+++ b/css/stanford_carousel.css
@@ -23,6 +23,7 @@
    background-position: center center;
    font-size: 0;
    color: transparent;
+   padding: 15px;
 }
 .carousel-controls .carousel-control:hover, .carousel-controls .carousel-control:focus {
    font-size: 0;
@@ -52,7 +53,7 @@
 .view.carousel .carousel-caption.carousel-light {color: #000000; background:none repeat scroll 0 0 rgba(255, 255, 255, 0.75);}
 .view.carousel .carousel-caption.carousel-light h2 a, .view.carousel .carousel-caption.carousel-light .slide-caption a { color: #000000; }
 .view.carousel .carousel-caption.carousel-dark a.more-link, .view.carousel .carousel-caption.carousel-dark .more-link a { color: #00a1f1;} /* color for OFW more-link */
-.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover, 
+.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
 .view.carousel .carousel-caption.carousel-dark a.more-link:focus, .view.carousel .carousel-caption.carousel-dark .more-link a:focus { color: #EEEEEE;} /* color for OFW more-link hover */
 
 /* Carousel slide title color */
@@ -86,7 +87,7 @@
 @media (max-width: 979px) {
 .view.carousel .carousel-caption h2, #content-body .view.carousel .carousel-caption h2 {font-size: 20px; margin-top: 10px;}
 }
-@media (min-width: 768px) and (max-width: 979px) { 
+@media (min-width: 768px) and (max-width: 979px) {
 .view.carousel .carousel-caption.carousel-position-left, .view.carousel .carousel-caption.carousel-position-right {width: 100%; max-width: 100%; padding: 15px 65px; position: inherit; }
 .view.carousel .carousel-block .carousel-caption {position: relative; width:100%; max-width: 100%; padding: 20px 70px; margin-top: -2px;}
 .view.carousel .carousel-control {top:auto; bottom:30%; width:30px; height: 30px; font-size:40px; line-height:20px;}
@@ -96,11 +97,11 @@
 #main-content .carousel img { -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; border: 15px solid #F5F5F5; } /* color for OFW slide bkg */
 .view.carousel .carousel-caption.carousel-dark,
 .view.carousel .carousel-caption.carousel-dark h2 a, .view.carousel .carousel-caption.carousel-dark .slide-caption a,
-.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover, 
+.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
 .view.carousel .carousel-caption.carousel-dark a.more-link:focus, .view.carousel .carousel-caption.carousel-dark .more-link a:focus {color: #000000;}
 .view.carousel .carousel-caption.carousel-dark { background: #F5F5F5; } /* color for OFW slide bkg */
 .view.carousel .carousel-caption.carousel-dark a.more-link, .view.carousel .carousel-caption.carousel-dark .more-link a { color: #006395;} /* color for OFW more-link (normal) */
-.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover, 
+.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
 .view.carousel .carousel-caption.carousel-dark a.more-link:focus, .view.carousel .carousel-caption.carousel-dark .more-link a:focus { color: #000000;} /* color for OFW more-link hover */
 }
 @media (max-width: 767px) {
@@ -116,10 +117,10 @@
 #main-content .carousel img { -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; border: 15px solid #F5F5F5; } /* color for OFW slide bkg */
 .view.carousel .carousel-caption.carousel-dark,
 .view.carousel .carousel-caption.carousel-dark h2 a, .view.carousel .carousel-caption.carousel-dark .slide-caption a,
-.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover, 
+.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
 .view.carousel .carousel-caption.carousel-dark a.more-link:focus, .view.carousel .carousel-caption.carousel-dark .more-link a:focus {color: #000000;}
 .view.carousel .carousel-caption.carousel-dark { background: #F5F5F5; } /* color for OFW slide bkg */
 .view.carousel .carousel-caption.carousel-dark a.more-link, .view.carousel .carousel-caption.carousel-dark .more-link a { color: #006395;} /* color for OFW more-link (normal) */
-.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover, 
+.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
 .view.carousel .carousel-caption.carousel-dark a.more-link:focus, .view.carousel .carousel-caption.carousel-dark .more-link a:focus { color: #000000;} /* color for OFW more-link hover */
 }


### PR DESCRIPTION
The previous and next buttons in the carousel were being stretched on mobile (only noticeable when viewing on an actual mobile device, not by resizing browser):

![mobile-carousel](https://cloud.githubusercontent.com/assets/8933670/22991370/db5dd5f4-f370-11e6-8035-89edb383a79f.png)

This was a result of using em rather than px for adding padding at an inherited level. This fix addresses that.