### PR TITLE
HSDO-1164 added styles for removing the overlay on carousel

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,24 +1,130 @@
 engines:
+  # https://docs.codeclimate.com/docs/eslint
+  # ES Linting requires an .eslintrc file to tweak checks.
   eslint:
-    enabled: true
+    enabled: false
   csslint:
     enabled: true
-  phpcodesniffer:
-    enabled: true
-    config:
-      file_extensions: "php,inc,install,module,profile"
-      standard: "Drupal"
-  phpmd:
-    enabled: true
-    config:
-      file_extensions:
-      - inc
-      - module
-      - profile
-      - php
-      - install
+    checks:
+      overqualified-elements:
+        enabled: false
+      order-alphabetical:
+        enabled: false
+      adjoining-classes:
+        enabled: false
+      fallback-colors:
+        enabled: false
+      ids:
+        enabled: false
+      regex-selectors:
+        enabled: false
+  # We don't lint our coffee. Eew.
+  coffeelint:
+    enabled: false
+  # SCSS Lint requires a .scss-lint.yml file in the repo in order to tweak settings.
+  # Withouth the .scss-lint.yml file it will run with the defaults.
+  # Defaults file: https://github.com/brigade/scss-lint/blob/master/config/default.yml
   scss-lint:
     enabled: true
+    checks:
+      IdSelector:
+        enabled: false
+      SelectorFormat:
+        enabled: false
+      NestingDepth:
+        enabled: false
+      MergeableSelector:
+        enabled: false
+      ColorVariable:
+        enabled: false
+      PropertySortOrder:
+        enabled: false
+      SelectorDepth:
+        enabled: false
+      QualifyingElement:
+        enabled: false
+      VendorPrefix:
+        enabled: false
+      LeadingZero:
+        enabled: false
+      HexLength:
+        enabled: false
+      PseudoElement:
+        enabled: false
+  phpcodesniffer:
+    enabled: true
+    checks:
+      Drupal Commenting FunctionComment TypeHintMissing:
+        enabled: false
+      Drupal Commenting FunctionComment IncorrectTypeHint:
+        enabled: false
+      DrupalPractice Commenting CommentEmptyLine SpacingAfter:
+        enabled: false
+      Drupal NamingConventions ValidFunctionName ScopeNotCamelCaps:
+        enabled: false
+      Drupal NamingConventions ValidClassName StartWithCaptial:
+        enabled: false
+      Drupal NamingConventions ValidFunctionName NotCamelCaps:
+        enabled: false
+      DrupalPractice General ClassName ClassPrefix:
+        enabled: false
+      Drupal NamingConventions ValidClassName NoUnderscores:
+        enabled: false
+    config:
+      file_extensions: "php,inc,install,module,profile"
+      standard: "Drupal,DrupalPractice"
+  phpmd:
+    enabled: true
+    checks:
+      Design/WeightedMethodCount:
+        enabled: false
+      CleanCode/StaticAccess:
+        enabled: false
+      CleanCode/ElseExpression:
+        enabled: false
+      CleanCode/BooleanArgumentFlag:
+        enabled: false
+      UnusedFormalParameter:
+        enabled: false
+    config:
+      # https://phpmd.org/rules/index.html
+      # The following sets include everything except the controversial set.
+      # We can configure these further through .xml files. See docs.
+      rulesets: "cleancode,codesize,design,naming,unusedcode"
+      # Include special Drupal file extensions.
+      file_extensions: "inc,module,profile,php,install"
+  # https://docs.codeclimate.com/docs/phan
+  phan:
+    enabled: true
+    config:
+      file_extensions: "php,module,profile,inc,install"
+      # minimum-severity: 1
+      ignore-undeclared: true
+      # quick: true
+      # backward-compatiility-checks: true
+      # dead-code-detection: true
+  # https://docs.codeclimate.com/docs/duplication
+  duplication:
+    enabled: true
+    # exclude_paths:
+    #   - examples/
+    config:
+      languages:
+        javascript:
+          mass_threshold: 50
+          # count_threshold: 3
+        php:
+          mass_threshold: 60
+  fixme:
+    enabled: true
+    config:
+      strings:
+      - FIXME
+      - BUG
+      - TODO
+      - todo
+      - dpm
+      - dsm
 ratings:
   paths:
   - "**.inc"
@@ -26,11 +132,10 @@ ratings:
   - "**.profile"
   - "**.php"
   - "**.install"
-  - "**.css"
   - "**.scss"
   - "**.sass"
   - "**.js"
-##exclude these files/paths
+# exclude these files/paths
 exclude_paths:
 - "**.features.**"
 - "**.views_default.inc"
@@ -41,3 +146,10 @@ exclude_paths:
 - "test/**/*"
 - "**/vendor/**/*"
 - "**.min.*"
+- "tests/"
+- "spec/"
+- "**/vendor/"
+- "**.api.php"
+- "*.twig"
+- "**.tpl.php"
+- "**.strongarm.inc"

--- a/css/stanford_carousel.css
+++ b/css/stanford_carousel.css
@@ -195,7 +195,7 @@
 }
 
 .view.carousel .carousel-indicators li a {
-  margin-left: -99999px
+  margin-left: -99999px;
 }
 
 /* Carousel controls */
@@ -418,11 +418,11 @@
 .view.carousel.no-overlay .carousel-caption,
 .view.carousel.no-overlay .carousel-block .carousel-caption {
   position: static;
-  background-color: black;
+  background-color: #000;
 }
 
 .view.carousel.no-overlay .carousel-caption.carousel-light {
-  background-color: white;
+  background-color: #fff;
 }
 
 @media (max-width: 979px) and (min-width: 768px) {

--- a/css/stanford_carousel.css
+++ b/css/stanford_carousel.css
@@ -1,9 +1,11 @@
 /* Styles for the Stanford Carousel Feature */
 
 /* GENERAL STYLES ************************ */
+
 .offscreen {
   position: absolute;
-  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+  clip: rect(1px 1px 1px 1px);
+  /* IE6, IE7 */
   clip: rect(1px, 1px, 1px, 1px);
   padding: 0;
   border: 0;
@@ -14,113 +16,425 @@
 }
 
 /* CAROUSEL STYLES *********************** */
-#block-views-stanford-carousel-span-9-block, #block-views-stanford-carousel-span-12-block {margin-bottom:0px;}
+
+#block-views-stanford-carousel-span-9-block,
+#block-views-stanford-carousel-span-12-block {
+  margin-bottom: 0px;
+}
 
 /* Hide the arrows and replace them with background images */
+
 .carousel-controls .carousel-control {
-   background-image: url('../images/btn-arrow-right.png');
-   background-repeat: no-repeat;
-   background-position: center center;
-   font-size: 0;
-   color: transparent;
-   padding: 15px;
+  background-image: url('../images/btn-arrow-right.png');
+  background-repeat: no-repeat;
+  background-position: center center;
+  font-size: 0;
+  color: transparent;
+  padding: 15px;
 }
-.carousel-controls .carousel-control:hover, .carousel-controls .carousel-control:focus {
-   font-size: 0;
-   color: transparent;
+
+.carousel-controls .carousel-control:hover,
+.carousel-controls .carousel-control:focus {
+  font-size: 0;
+  color: transparent;
 }
+
 .carousel-controls .carousel-control.left {
-   background-image: url('../images/btn-arrow-left.png');
+  background-image: url('../images/btn-arrow-left.png');
 }
 
 /* Carousel caption defaults */
-.view.carousel .carousel-caption .slide-caption {letter-spacing: 0.02em; line-height: 1.4em;}
-.view.carousel .carousel-caption .slide-caption a:hover {text-decoration: none;}
-.view.carousel .carousel-caption h2 {margin-top:0px;}
-.view.carousel .carousel-caption h2 a:hover {text-decoration: none;}
-.view.carousel .carousel-caption {-moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;}
+
+.view.carousel .carousel-caption .slide-caption {
+  letter-spacing: 0.02em;
+  line-height: 1.4em;
+}
+
+.view.carousel .carousel-caption .slide-caption a:hover {
+  text-decoration: none;
+}
+
+.view.carousel .carousel-caption h2 {
+  margin-top: 0px;
+}
+
+.view.carousel .carousel-caption h2 a:hover {
+  text-decoration: none;
+}
+
+.view.carousel .carousel-caption {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
 
 /* Carousel caption position */
-.view.carousel .carousel-caption.carousel-position-top {top: 10%; bottom:auto;}
-.view.carousel .carousel-caption.carousel-position-bottom {bottom: 10%; }
-.view.carousel .carousel-caption.carousel-position-left, .view.carousel .carousel-caption.carousel-position-right {width: 70%; max-width: 70%; padding: 15px 25px;}
-.view.carousel .carousel-caption.carousel-position-left {left: 0; right: auto; padding-left: 70px;}
-.view.carousel .carousel-caption.carousel-position-right {left: auto; right: 0; padding-right: 70px;}
+
+.view.carousel .carousel-caption.carousel-position-top {
+  top: 10%;
+  bottom: auto;
+}
+
+.view.carousel .carousel-caption.carousel-position-bottom {
+  bottom: 10%;
+}
+
+.view.carousel .carousel-caption.carousel-position-left,
+.view.carousel .carousel-caption.carousel-position-right {
+  width: 70%;
+  max-width: 70%;
+  padding: 15px 25px;
+}
+
+.view.carousel .carousel-caption.carousel-position-left {
+  left: 0;
+  right: auto;
+  padding-left: 70px;
+}
+
+.view.carousel .carousel-caption.carousel-position-right {
+  left: auto;
+  right: 0;
+  padding-right: 70px;
+}
 
 /* Carousel caption color */
-.view.carousel .carousel-caption.carousel-dark {color: #EEEEEE;}
-.view.carousel .carousel-caption.carousel-dark h2 a, .view.carousel .carousel-caption.carousel-dark .slide-caption a { color: #EEEEEE; }
-.view.carousel .carousel-caption.carousel-light {color: #000000; background:none repeat scroll 0 0 rgba(255, 255, 255, 0.75);}
-.view.carousel .carousel-caption.carousel-light h2 a, .view.carousel .carousel-caption.carousel-light .slide-caption a { color: #000000; }
-.view.carousel .carousel-caption.carousel-dark a.more-link, .view.carousel .carousel-caption.carousel-dark .more-link a { color: #00a1f1;} /* color for OFW more-link */
-.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
-.view.carousel .carousel-caption.carousel-dark a.more-link:focus, .view.carousel .carousel-caption.carousel-dark .more-link a:focus { color: #EEEEEE;} /* color for OFW more-link hover */
+
+.view.carousel .carousel-caption.carousel-dark {
+  color: #EEEEEE;
+}
+
+.view.carousel .carousel-caption.carousel-dark h2 a,
+.view.carousel .carousel-caption.carousel-dark .slide-caption a {
+  color: #EEEEEE;
+}
+
+.view.carousel .carousel-caption.carousel-light {
+  color: #000000;
+  background: none repeat scroll 0 0 rgba(255, 255, 255, 0.75);
+}
+
+.view.carousel .carousel-caption.carousel-light h2 a,
+.view.carousel .carousel-caption.carousel-light .slide-caption a {
+  color: #000000;
+}
+
+.view.carousel .carousel-caption.carousel-dark a.more-link,
+.view.carousel .carousel-caption.carousel-dark .more-link a {
+  color: #00a1f1;
+}
+
+/* color for OFW more-link */
+
+.view.carousel .carousel-caption.carousel-dark a.more-link:hover,
+.view.carousel .carousel-caption.carousel-dark .more-link a:hover,
+.view.carousel .carousel-caption.carousel-dark a.more-link:focus,
+.view.carousel .carousel-caption.carousel-dark .more-link a:focus {
+  color: #EEEEEE;
+}
+
+/* color for OFW more-link hover */
 
 /* Carousel slide title color */
-.carousel-dark .slide-title {color: #EEEEEE;}
+
+.carousel-dark .slide-title {
+  color: #EEEEEE;
+}
 
 /* Carousel block display styles */
-.view.carousel .carousel-block .carousel-caption { bottom: 1px; display: block; position: absolute; top: 0; width: 34%; overflow:hidden; }
-.view.carousel .carousel-block .carousel-caption.carousel-position-left {left: 0; right: auto; padding: 20px 25px 25px 75px;}
-.view.carousel .carousel-block .carousel-caption.carousel-position-right {left: auto; right: 0; padding: 20px 75px 25px 25px;}
+
+.view.carousel .carousel-block .carousel-caption {
+  bottom: 1px;
+  display: block;
+  position: absolute;
+  top: 0;
+  width: 34%;
+  overflow: hidden;
+}
+
+.view.carousel .carousel-block .carousel-caption.carousel-position-left {
+  left: 0;
+  right: auto;
+  padding: 20px 25px 25px 75px;
+}
+
+.view.carousel .carousel-block .carousel-caption.carousel-position-right {
+  left: auto;
+  right: 0;
+  padding: 20px 75px 25px 25px;
+}
 
 /* Carousel dots */
-.view.carousel .carousel-indicators {margin:0 auto; text-align:center; position: relative; right: auto; top: auto; z-index: auto; }
-.view.carousel .carousel-indicators li {background-color: #FFFFFF; border: 1px solid #666666; border-radius: 7px; display: inline-block; float: none; height: 12px; width: 12px;}
-.view.carousel .carousel-indicators .active {background-color: #666666;}
-.view.carousel .carousel-indicators li:hover {cursor: pointer; background-color: #666666;}
-.view.carousel .carousel-indicators li a {margin-left: -99999px}
+
+.view.carousel .carousel-indicators {
+  margin: 0 auto;
+  text-align: center;
+  position: relative;
+  right: auto;
+  top: auto;
+  z-index: auto;
+}
+
+.view.carousel .carousel-indicators li {
+  background-color: #FFFFFF;
+  border: 1px solid #666666;
+  border-radius: 7px;
+  display: inline-block;
+  float: none;
+  height: 12px;
+  width: 12px;
+}
+
+.view.carousel .carousel-indicators .active {
+  background-color: #666666;
+}
+
+.view.carousel .carousel-indicators li:hover {
+  cursor: pointer;
+  background-color: #666666;
+}
+
+.view.carousel .carousel-indicators li a {
+  margin-left: -99999px
+}
 
 /* Carousel controls */
-.view.carousel .carousel-controls {height: 0px;}
-.view.carousel .carousel-control, .view.carousel .carousel-control:focus {opacity:0.3;}
-.view.carousel .carousel-control:hover {opacity:0.9;}
-.view.carousel .carousel-control:focus {outline: 1px dotted #444444;}
+
+.view.carousel .carousel-controls {
+  height: 0px;
+}
+
+.view.carousel .carousel-control,
+.view.carousel .carousel-control:focus {
+  opacity: 0.3;
+}
+
+.view.carousel .carousel-control:hover {
+  opacity: 0.9;
+}
+
+.view.carousel .carousel-control:focus {
+  outline: 1px dotted #444444;
+}
 
 /* Carousel Image */
-#main-content .carousel img { border: medium none; }
+
+#main-content .carousel img {
+  border: medium none;
+}
 
 /* Carousel media queries */
+
 @media (max-width: 1199px) {
-.view.carousel .carousel-block .carousel-caption {width: 50%;}
+  .view.carousel .carousel-block .carousel-caption {
+    width: 50%;
+  }
 }
+
 @media (max-width: 979px) {
-.view.carousel .carousel-caption h2, #content-body .view.carousel .carousel-caption h2 {font-size: 20px; margin-top: 10px;}
+  .view.carousel .carousel-caption h2,
+  #content-body .view.carousel .carousel-caption h2 {
+    font-size: 20px;
+    margin-top: 10px;
+  }
 }
+
 @media (min-width: 768px) and (max-width: 979px) {
-.view.carousel .carousel-caption.carousel-position-left, .view.carousel .carousel-caption.carousel-position-right {width: 100%; max-width: 100%; padding: 15px 65px; position: inherit; }
-.view.carousel .carousel-block .carousel-caption {position: relative; width:100%; max-width: 100%; padding: 20px 70px; margin-top: -2px;}
-.view.carousel .carousel-control {top:auto; bottom:30%; width:30px; height: 30px; font-size:40px; line-height:20px;}
-.view.carousel .carousel-block .carousel-caption.carousel-light, .view.carousel .carousel-caption.carousel-light { background: #F5F5F5; } /* color for OFW slide bkg */
-.view.carousel .carousel-block .carousel-caption.carousel-position-left,  .view.carousel .carousel-block .carousel-caption.carousel-position-right { padding: 20px 70px; }
-.view.carousel .carousel-control { bottom: auto; top: 30%; }
-#main-content .carousel img { -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; border: 15px solid #F5F5F5; } /* color for OFW slide bkg */
-.view.carousel .carousel-caption.carousel-dark,
-.view.carousel .carousel-caption.carousel-dark h2 a, .view.carousel .carousel-caption.carousel-dark .slide-caption a,
-.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
-.view.carousel .carousel-caption.carousel-dark a.more-link:focus, .view.carousel .carousel-caption.carousel-dark .more-link a:focus {color: #000000;}
-.view.carousel .carousel-caption.carousel-dark { background: #F5F5F5; } /* color for OFW slide bkg */
-.view.carousel .carousel-caption.carousel-dark a.more-link, .view.carousel .carousel-caption.carousel-dark .more-link a { color: #006395;} /* color for OFW more-link (normal) */
-.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
-.view.carousel .carousel-caption.carousel-dark a.more-link:focus, .view.carousel .carousel-caption.carousel-dark .more-link a:focus { color: #000000;} /* color for OFW more-link hover */
+  .view.carousel .carousel-caption.carousel-position-left,
+  .view.carousel .carousel-caption.carousel-position-right {
+    width: 100%;
+    max-width: 100%;
+    padding: 15px 65px;
+    position: inherit;
+  }
+  .view.carousel .carousel-block .carousel-caption {
+    position: relative;
+    width: 100%;
+    max-width: 100%;
+    padding: 20px 70px;
+    margin-top: -2px;
+  }
+  .view.carousel .carousel-control {
+    top: auto;
+    bottom: 30%;
+    width: 30px;
+    height: 30px;
+    font-size: 40px;
+    line-height: 20px;
+  }
+  .view.carousel .carousel-block .carousel-caption.carousel-light,
+  .view.carousel .carousel-caption.carousel-light {
+    background: #F5F5F5;
+  }
+  /* color for OFW slide bkg */
+  .view.carousel .carousel-block .carousel-caption.carousel-position-left,
+  .view.carousel .carousel-block .carousel-caption.carousel-position-right {
+    padding: 20px 70px;
+  }
+  .view.carousel .carousel-control {
+    bottom: auto;
+    top: 30%;
+  }
+  #main-content .carousel img {
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    border: 15px solid #F5F5F5;
+  }
+  /* color for OFW slide bkg */
+  .view.carousel .carousel-caption.carousel-dark,
+  .view.carousel .carousel-caption.carousel-dark h2 a,
+  .view.carousel .carousel-caption.carousel-dark .slide-caption a,
+  .view.carousel .carousel-caption.carousel-dark a.more-link:hover,
+  .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
+  .view.carousel .carousel-caption.carousel-dark a.more-link:focus,
+  .view.carousel .carousel-caption.carousel-dark .more-link a:focus {
+    color: #000000;
+  }
+  .view.carousel .carousel-caption.carousel-dark {
+    background: #F5F5F5;
+  }
+  /* color for OFW slide bkg */
+  .view.carousel .carousel-caption.carousel-dark a.more-link,
+  .view.carousel .carousel-caption.carousel-dark .more-link a {
+    color: #006395;
+  }
+  /* color for OFW more-link (normal) */
+  .view.carousel .carousel-caption.carousel-dark a.more-link:hover,
+  .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
+  .view.carousel .carousel-caption.carousel-dark a.more-link:focus,
+  .view.carousel .carousel-caption.carousel-dark .more-link a:focus {
+    color: #000000;
+  }
+  /* color for OFW more-link hover */
 }
+
 @media (max-width: 767px) {
-.view.carousel .carousel-block .carousel-caption {width: 50%;}
+  .view.carousel .carousel-block .carousel-caption {
+    width: 50%;
+  }
 }
+
 @media (max-width: 630px) {
-.view.carousel .carousel-caption.carousel-position-left, .view.carousel .carousel-caption.carousel-position-right {width: 100%; max-width: 100%; padding: 15px 65px; position: inherit; }
-.view.carousel .carousel-block .carousel-caption {position: relative; width:100%; max-width: 100%; padding: 20px 70px; margin-top: -2px;}
-.view.carousel .carousel-control {top:auto; bottom:30%; width:30px; height: 30px; font-size:40px; line-height:20px;}
-.view.carousel .carousel-block .carousel-caption.carousel-light, .view.carousel .carousel-caption.carousel-light { background: #F5F5F5; } /* color for OFW slide bkg */
-.view.carousel .carousel-block .carousel-caption.carousel-position-left,  .view.carousel .carousel-block .carousel-caption.carousel-position-right { padding: 20px 70px; }
-.view.carousel .carousel-control { bottom: auto; top: 30%; }
-#main-content .carousel img { -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; border: 15px solid #F5F5F5; } /* color for OFW slide bkg */
-.view.carousel .carousel-caption.carousel-dark,
-.view.carousel .carousel-caption.carousel-dark h2 a, .view.carousel .carousel-caption.carousel-dark .slide-caption a,
-.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
-.view.carousel .carousel-caption.carousel-dark a.more-link:focus, .view.carousel .carousel-caption.carousel-dark .more-link a:focus {color: #000000;}
-.view.carousel .carousel-caption.carousel-dark { background: #F5F5F5; } /* color for OFW slide bkg */
-.view.carousel .carousel-caption.carousel-dark a.more-link, .view.carousel .carousel-caption.carousel-dark .more-link a { color: #006395;} /* color for OFW more-link (normal) */
-.view.carousel .carousel-caption.carousel-dark a.more-link:hover, .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
-.view.carousel .carousel-caption.carousel-dark a.more-link:focus, .view.carousel .carousel-caption.carousel-dark .more-link a:focus { color: #000000;} /* color for OFW more-link hover */
+  .view.carousel .carousel-caption.carousel-position-left,
+  .view.carousel .carousel-caption.carousel-position-right {
+    width: 100%;
+    max-width: 100%;
+    padding: 15px 65px;
+    position: inherit;
+  }
+  .view.carousel .carousel-block .carousel-caption {
+    position: relative;
+    width: 100%;
+    max-width: 100%;
+    padding: 20px 70px;
+    margin-top: -2px;
+  }
+  .view.carousel .carousel-control {
+    top: auto;
+    bottom: 30%;
+    width: 30px;
+    height: 30px;
+    font-size: 40px;
+    line-height: 20px;
+  }
+  .view.carousel .carousel-block .carousel-caption.carousel-light,
+  .view.carousel .carousel-caption.carousel-light {
+    background: #F5F5F5;
+  }
+  /* color for OFW slide bkg */
+  .view.carousel .carousel-block .carousel-caption.carousel-position-left,
+  .view.carousel .carousel-block .carousel-caption.carousel-position-right {
+    padding: 20px 70px;
+  }
+  .view.carousel .carousel-control {
+    bottom: auto;
+    top: 30%;
+  }
+  #main-content .carousel img {
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    border: 15px solid #F5F5F5;
+  }
+  /* color for OFW slide bkg */
+  .view.carousel .carousel-caption.carousel-dark,
+  .view.carousel .carousel-caption.carousel-dark h2 a,
+  .view.carousel .carousel-caption.carousel-dark .slide-caption a,
+  .view.carousel .carousel-caption.carousel-dark a.more-link:hover,
+  .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
+  .view.carousel .carousel-caption.carousel-dark a.more-link:focus,
+  .view.carousel .carousel-caption.carousel-dark .more-link a:focus {
+    color: #000000;
+  }
+  .view.carousel .carousel-caption.carousel-dark {
+    background: #F5F5F5;
+  }
+  /* color for OFW slide bkg */
+  .view.carousel .carousel-caption.carousel-dark a.more-link,
+  .view.carousel .carousel-caption.carousel-dark .more-link a {
+    color: #006395;
+  }
+  /* color for OFW more-link (normal) */
+  .view.carousel .carousel-caption.carousel-dark a.more-link:hover,
+  .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
+  .view.carousel .carousel-caption.carousel-dark a.more-link:focus,
+  .view.carousel .carousel-caption.carousel-dark .more-link a:focus {
+    color: #000000;
+  }
+  /* color for OFW more-link hover */
+}
+
+/* No overlay carousel styles */
+
+.view.carousel.no-overlay .carousel-caption.carousel-position-left,
+.view.carousel.no-overlay .carousel-caption.carousel-position-right {
+  width: 100%;
+  max-width: 100%;
+}
+
+.view.carousel.no-overlay .carousel-caption,
+.view.carousel.no-overlay .carousel-block .carousel-caption {
+  position: static;
+  background-color: black;
+}
+
+.view.carousel.no-overlay .carousel-caption.carousel-light {
+  background-color: white;
+}
+
+@media (max-width: 979px) and (min-width: 768px) {
+  .view.carousel.no-overlay .carousel-caption.carousel-dark {
+    background: #000000;
+  }
+}
+
+@media (max-width: 630px) {
+  .view.carousel.no-overlay .carousel-caption.carousel-dark {
+    background: #000000;
+  }
+}
+
+@media (max-width: 979px) and (min-width: 768px) {
+  .view.carousel.no-overlay .carousel-caption.carousel-dark,
+  .view.carousel.no-overlay .carousel-caption.carousel-dark .more-link a:focus,
+  .view.carousel.no-overlay .carousel-caption.carousel-dark .more-link a:hover,
+  .view.carousel.no-overlay .carousel-caption.carousel-dark .slide-caption a,
+  .view.carousel.no-overlay .carousel-caption.carousel-dark a.more-link:focus,
+  .view.carousel.no-overlay .carousel-caption.carousel-dark a.more-link:hover,
+  .view.carousel.no-overlay .carousel-caption.carousel-dark h2 a {
+    color: #ffffff;
+  }
+}
+
+@media (max-width: 630px) {
+  .view.carousel.no-overlay .carousel-caption.carousel-dark,
+  .view.carousel.no-overlay .carousel-caption.carousel-dark .more-link a:focus,
+  .view.carousel.no-overlay .carousel-caption.carousel-dark .more-link a:hover,
+  .view.carousel.no-overlay .carousel-caption.carousel-dark .slide-caption a,
+  .view.carousel.no-overlay .carousel-caption.carousel-dark a.more-link:focus,
+  .view.carousel.no-overlay .carousel-caption.carousel-dark a.more-link:hover,
+  .view.carousel.no-overlay .carousel-caption.carousel-dark h2 a {
+    color: #ffffff;
+  }
 }

--- a/css/stanford_carousel.css
+++ b/css/stanford_carousel.css
@@ -101,22 +101,22 @@
 /* Carousel caption color */
 
 .view.carousel .carousel-caption.carousel-dark {
-  color: #EEEEEE;
+  color: #eee;
 }
 
 .view.carousel .carousel-caption.carousel-dark h2 a,
 .view.carousel .carousel-caption.carousel-dark .slide-caption a {
-  color: #EEEEEE;
+  color: #eee;
 }
 
 .view.carousel .carousel-caption.carousel-light {
-  color: #000000;
+  color: #000;
   background: none repeat scroll 0 0 rgba(255, 255, 255, 0.75);
 }
 
 .view.carousel .carousel-caption.carousel-light h2 a,
 .view.carousel .carousel-caption.carousel-light .slide-caption a {
-  color: #000000;
+  color: #000;
 }
 
 .view.carousel .carousel-caption.carousel-dark a.more-link,
@@ -130,7 +130,7 @@
 .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
 .view.carousel .carousel-caption.carousel-dark a.more-link:focus,
 .view.carousel .carousel-caption.carousel-dark .more-link a:focus {
-  color: #EEEEEE;
+  color: #eee;
 }
 
 /* color for OFW more-link hover */
@@ -138,7 +138,7 @@
 /* Carousel slide title color */
 
 .carousel-dark .slide-title {
-  color: #EEEEEE;
+  color: #eee;
 }
 
 /* Carousel block display styles */
@@ -176,8 +176,8 @@
 }
 
 .view.carousel .carousel-indicators li {
-  background-color: #FFFFFF;
-  border: 1px solid #666666;
+  background-color: #fff;
+  border: 1px solid #666;
   border-radius: 7px;
   display: inline-block;
   float: none;
@@ -186,12 +186,12 @@
 }
 
 .view.carousel .carousel-indicators .active {
-  background-color: #666666;
+  background-color: #666;
 }
 
 .view.carousel .carousel-indicators li:hover {
   cursor: pointer;
-  background-color: #666666;
+  background-color: #666;
 }
 
 .view.carousel .carousel-indicators li a {
@@ -214,7 +214,7 @@
 }
 
 .view.carousel .carousel-control:focus {
-  outline: 1px dotted #444444;
+  outline: 1px dotted #444;
 }
 
 /* Carousel Image */
@@ -247,6 +247,7 @@
     padding: 15px 65px;
     position: inherit;
   }
+
   .view.carousel .carousel-block .carousel-caption {
     position: relative;
     width: 100%;
@@ -254,6 +255,7 @@
     padding: 20px 70px;
     margin-top: -2px;
   }
+
   .view.carousel .carousel-control {
     top: auto;
     bottom: 30%;
@@ -262,25 +264,30 @@
     font-size: 40px;
     line-height: 20px;
   }
+
   .view.carousel .carousel-block .carousel-caption.carousel-light,
   .view.carousel .carousel-caption.carousel-light {
-    background: #F5F5F5;
+    background: #f5f5f5;
   }
+
   /* color for OFW slide bkg */
   .view.carousel .carousel-block .carousel-caption.carousel-position-left,
   .view.carousel .carousel-block .carousel-caption.carousel-position-right {
     padding: 20px 70px;
   }
+
   .view.carousel .carousel-control {
     bottom: auto;
     top: 30%;
   }
+
   #main-content .carousel img {
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
-    border: 15px solid #F5F5F5;
+    border: 15px solid #f5f5f5;
   }
+
   /* color for OFW slide bkg */
   .view.carousel .carousel-caption.carousel-dark,
   .view.carousel .carousel-caption.carousel-dark h2 a,
@@ -289,23 +296,27 @@
   .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
   .view.carousel .carousel-caption.carousel-dark a.more-link:focus,
   .view.carousel .carousel-caption.carousel-dark .more-link a:focus {
-    color: #000000;
+    color: #000;
   }
+
   .view.carousel .carousel-caption.carousel-dark {
-    background: #F5F5F5;
+    background: #f5f5f5;
   }
+
   /* color for OFW slide bkg */
   .view.carousel .carousel-caption.carousel-dark a.more-link,
   .view.carousel .carousel-caption.carousel-dark .more-link a {
     color: #006395;
   }
+
   /* color for OFW more-link (normal) */
   .view.carousel .carousel-caption.carousel-dark a.more-link:hover,
   .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
   .view.carousel .carousel-caption.carousel-dark a.more-link:focus,
   .view.carousel .carousel-caption.carousel-dark .more-link a:focus {
-    color: #000000;
+    color: #000;
   }
+
   /* color for OFW more-link hover */
 }
 
@@ -323,6 +334,7 @@
     padding: 15px 65px;
     position: inherit;
   }
+
   .view.carousel .carousel-block .carousel-caption {
     position: relative;
     width: 100%;
@@ -330,6 +342,7 @@
     padding: 20px 70px;
     margin-top: -2px;
   }
+
   .view.carousel .carousel-control {
     top: auto;
     bottom: 30%;
@@ -338,25 +351,30 @@
     font-size: 40px;
     line-height: 20px;
   }
+
   .view.carousel .carousel-block .carousel-caption.carousel-light,
   .view.carousel .carousel-caption.carousel-light {
-    background: #F5F5F5;
+    background: #f5f5f5;
   }
+
   /* color for OFW slide bkg */
   .view.carousel .carousel-block .carousel-caption.carousel-position-left,
   .view.carousel .carousel-block .carousel-caption.carousel-position-right {
     padding: 20px 70px;
   }
+
   .view.carousel .carousel-control {
     bottom: auto;
     top: 30%;
   }
+
   #main-content .carousel img {
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
-    border: 15px solid #F5F5F5;
+    border: 15px solid #f5f5f5;
   }
+
   /* color for OFW slide bkg */
   .view.carousel .carousel-caption.carousel-dark,
   .view.carousel .carousel-caption.carousel-dark h2 a,
@@ -365,23 +383,27 @@
   .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
   .view.carousel .carousel-caption.carousel-dark a.more-link:focus,
   .view.carousel .carousel-caption.carousel-dark .more-link a:focus {
-    color: #000000;
+    color: #000;
   }
+
   .view.carousel .carousel-caption.carousel-dark {
-    background: #F5F5F5;
+    background: #f5f5f5;
   }
+
   /* color for OFW slide bkg */
   .view.carousel .carousel-caption.carousel-dark a.more-link,
   .view.carousel .carousel-caption.carousel-dark .more-link a {
     color: #006395;
   }
+
   /* color for OFW more-link (normal) */
   .view.carousel .carousel-caption.carousel-dark a.more-link:hover,
   .view.carousel .carousel-caption.carousel-dark .more-link a:hover,
   .view.carousel .carousel-caption.carousel-dark a.more-link:focus,
   .view.carousel .carousel-caption.carousel-dark .more-link a:focus {
-    color: #000000;
+    color: #000;
   }
+
   /* color for OFW more-link hover */
 }
 
@@ -405,13 +427,13 @@
 
 @media (max-width: 979px) and (min-width: 768px) {
   .view.carousel.no-overlay .carousel-caption.carousel-dark {
-    background: #000000;
+    background: #000;
   }
 }
 
 @media (max-width: 630px) {
   .view.carousel.no-overlay .carousel-caption.carousel-dark {
-    background: #000000;
+    background: #000;
   }
 }
 
@@ -423,7 +445,7 @@
   .view.carousel.no-overlay .carousel-caption.carousel-dark a.more-link:focus,
   .view.carousel.no-overlay .carousel-caption.carousel-dark a.more-link:hover,
   .view.carousel.no-overlay .carousel-caption.carousel-dark h2 a {
-    color: #ffffff;
+    color: #fff;
   }
 }
 
@@ -435,6 +457,6 @@
   .view.carousel.no-overlay .carousel-caption.carousel-dark a.more-link:focus,
   .view.carousel.no-overlay .carousel-caption.carousel-dark a.more-link:hover,
   .view.carousel.no-overlay .carousel-caption.carousel-dark h2 a {
-    color: #ffffff;
+    color: #fff;
   }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added styles for when **no-overlay** class is added to any carousel view

# Needed By (Date)
- End of sprint

# Urgency
- N/A

# Steps to Test

1. Pull this branch
2. Add **no-overlay** class to any carousel view
3. Overlay should sit above image

# Affected Projects or Products
- stanford_carousel
- stanford_jumpstart_home
- HSDO

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/HSDO-1164
- https://github.com/SU-SWS/stanford_jumpstart_home/pull/30

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)